### PR TITLE
Recover if git fails to run

### DIFF
--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -166,7 +166,7 @@ function generate_coverage(pkg; genhtml=true, show_summary=true, genxml=false)
                 try
                     strip(read(`git rev-parse --abbrev-ref HEAD`, String))
                 catch
-                    "(git branch could not be detected)"
+                    @warn "git branch could not be detected"
                 end
             title = "on branch $(branch)"
             run(`genhtml -t $(title) -o $(COVDIR) $(tracefile)`)

--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -162,7 +162,12 @@ function generate_coverage(pkg; genhtml=true, show_summary=true, genxml=false)
         tracefile = "$(COVDIR)/lcov.info"
         Coverage.LCOV.writefile(tracefile, coverage)
         if genhtml
-            branch = strip(read(`git rev-parse --abbrev-ref HEAD`, String))
+            branch =
+                try
+                    strip(read(`git rev-parse --abbrev-ref HEAD`, String))
+                catch
+                    "(git branch could not be detected)"
+                end
             title = "on branch $(branch)"
             run(`genhtml -t $(title) -o $(COVDIR) $(tracefile)`)
             @info("generated coverage HTML")


### PR DESCRIPTION
This enables coverage information to be generated even if the git branch cannot be determined.