### PR TITLE
Remove the `Coverage.jl` dependency, and instead depend only on `CoverageTools.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,17 @@
 name = "LocalCoverage"
 uuid = "5f6e1e16-694c-5876-87ef-16b5274f298e"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
-Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
+CoverageTools = "c36e975a-824b-4404-a568-ef97ca766997"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-Coverage = "1"
+CoverageTools = "1"
 DocStringExtensions = "0.8"
 PrettyTables = "0.12, 1.0"
 julia = "1.5"

--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -1,6 +1,6 @@
 module LocalCoverage
 
-using Coverage
+using CoverageTools
 using DocStringExtensions
 using Printf
 using PrettyTables
@@ -157,10 +157,10 @@ Use [`clean_coverage`](@ref) for cleaning.
 function generate_coverage(pkg; genhtml=true, show_summary=true, genxml=false)
     Pkg.test(pkg; coverage = true)
     coverage = cd(pkgdir(pkg)) do
-        coverage = Coverage.process_folder()
+        coverage = CoverageTools.process_folder()
         isdir(COVDIR) || mkdir(COVDIR)
         tracefile = "$(COVDIR)/lcov.info"
-        Coverage.LCOV.writefile(tracefile, coverage)
+        CoverageTools.LCOV.writefile(tracefile, coverage)
         if genhtml
             branch =
                 try
@@ -195,7 +195,7 @@ If `rm_directory`, will delete the coverage directory, otherwise only deletes
 function clean_coverage(pkg;
                         coverage_directory::AbstractString=COVDIR,
                         rm_directory::Bool=true)
-    Coverage.clean_folder(pkgdir(pkg))
+    CoverageTools.clean_folder(pkgdir(pkg))
     rm_directory && rm(joinpath(pkgdir(pkg), coverage_directory); force = true, recursive = true)
 end
 


### PR DESCRIPTION
If I understand correctly, for this package, you don't need any of the "upload to Codecov" or "upload to Coveralls" features from Coverage.jl.

In that case, you really only need to depend on CoverageTools.jl, which is much more lightweight and has no dependencies of its own (not even any stdlibs).