### PR TITLE
use function for get!

### DIFF
--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -14,7 +14,9 @@ const COVDIR = "coverage"
 "Coverage tracefile."
 const LCOVINFO = "lcov.info"
 
-const PYTHON = get!(ENV, "PYTHON", isnothing(Sys.which("python3")) ? "python" : "python3")
+const PYTHON = get!(ENV, "PYTHON") do
+    isnothing(Sys.which("python3")) ? "python" : "python3"
+end
 
 
 """


### PR DESCRIPTION
``` 
using LocalCoverage
```

is throwing errors for me. The problem is `Sys.which` (which I don't know how to solve...)

```
julia> Sys.which("python3")
ERROR: IOError: stat("C:\\Users\\brand\\AppData\\Local\\Microsoft\\WindowsApps\\python3.exe"): permission denied (EACCES)
Stacktrace:
 [1] uv_error
   @ .\libuv.jl:97 [inlined]
 [2] stat(path::String)
   @ Base.Filesystem .\stat.jl:152
 [3] isfile
   @ .\stat.jl:456 [inlined]
 [4] which(program_name::String)
   @ Base.Sys .\sysinfo.jl:518
 [5] top-level scope
   @ REPL[10]:1
```

So I changed `get!` to use a function so that it will only run `Sys.which` if the environmental variable isn't found. Then, I can set

```
ENV = "C:\\Users\\brand\\AppData\\Local\\Microsoft\\WindowsApps\\python3.exe"
```

and

``` 
using LocalCoverage
```

works




