### PR TITLE
Show relative filenames in coverage table

### DIFF
--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -168,13 +168,12 @@ end
 
 format_gap(gap) = length(gap) == 1 ? "$(first(gap))" : "$(first(gap)) - $(last(gap))"
 function format_line(summary)
-    hcat(
-        summary isa PackageCoverage ? "TOTAL" : summary.filename,
-        @sprintf("%3d / %3d", summary.lines_hit, summary.lines_tracked),
-        isnan(summary.coverage) ? "-" : @sprintf("%3.0f%%", summary.coverage),
-        summary isa PackageCoverage ? "" :
-        join(map(format_gap, summary.coverage_gaps), ", "),
-    )
+    name = (summary isa PackageCoverage ? "TOTAL" : relpath(summary.filename))
+    lines_hit = @sprintf("%3d / %3d", summary.lines_hit, summary.lines_tracked)
+    coverage = (isnan(summary.coverage) ? "-" : @sprintf("%3.0f%%", summary.coverage))
+    gaps = summary isa PackageCoverage ? "" :
+        join(map(format_gap, summary.coverage_gaps), ", ")
+    return hcat(name, lines_hit, coverage, gaps)
 end
 
 function Base.show(io::IO, coverage::PackageCoverage)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using LocalCoverage, Test
 const pkg = "LocalCoverage"     # we test the package with itself
 
 table_header = r"File name\s+.\s+Lines hit\s+.\s+Coverage\s+.\s+Missing"
-table_line = r"src(\/|\\\\)LocalCoverage.jl?\s+.\s+\d+\s*\/\s*\d+\s+.\s+\d+%\s+.\s+"
+table_line = r"(?<!\/|\\\\)src(\/|\\\\)LocalCoverage.jl?\s+.\s+\d+\s*\/\s*\d+\s+.\s+\d+%\s+.\s+"
 table_footer = r"TOTAL\s+.\s+\d+\s*\/\s*\d+\s+.\s+\d+%\s+.\s+."
 
 # prevent infinite recursion when testing
@@ -23,6 +23,7 @@ if !isfile(lockfile)
     buffer = IOBuffer()
     show(buffer, cov)
     table = String(take!(buffer))
+    println(table)
     @test !isnothing(match(table_header, table))
     @test !isnothing(match(table_line, table))
     @test !isnothing(match(table_footer, table))


### PR DESCRIPTION
This makes the table significantly more readable.

See https://github.com/JuliaCI/LocalCoverage.jl/issues/36#issuecomment-1240357696 Item 1

I took the liberty of refactoring the `format_line` function slightly for better readability and debuggability, and as a better starting point for "Item 2" of customizing the table output.