### PR TITLE
Allow passing custom CSS file to `html_coverage`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ Dates = "1.6"
 DefaultApplication = "1"
 DocStringExtensions = "0.8, 0.9"
 EzXML = "1"
+FileCmp = "1"
 LibGit2 = "1.6"
 OrderedCollections = "1"
 Pkg = "1.6"
@@ -32,6 +33,7 @@ julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+FileCmp = "343a5541-a696-4ae7-8102-bc61c09e1896"
 
 [targets]
-test = ["Test"]
+test = ["Test","FileCmp"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LocalCoverage"
 uuid = "5f6e1e16-694c-5876-87ef-16b5274f298e"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"

--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -286,7 +286,7 @@ inside `dir`.
 
 See [`generate_coverage`](@ref).
 """
-function html_coverage(coverage::PackageCoverage; gitroot = ".", open = false, dir = tempdir())
+function html_coverage(coverage::PackageCoverage; gitroot = ".", open = false, dir = tempdir(), css::Union{Nothing,String}=nothing)
     cd(coverage.package_dir) do
         branch = try
             LibGit2.headname(GitRepo(gitroot))
@@ -298,7 +298,13 @@ function html_coverage(coverage::PackageCoverage; gitroot = ".", open = false, d
         tracefile = joinpath(COVDIR, LCOVINFO)
 
         try
-            run(`genhtml -t $(title) -o $(dir) $(tracefile)`)
+            cmd = `genhtml -t $(title) -o $(dir) $(tracefile)`
+            if !isnothing(css)
+                css_file = abspath(css)
+                isfile(css_file) || throw(ArgumentError("Could not find CSS file at $(css_file)"))
+                cmd = `$(cmd) --css-file $(css_file)`
+            end
+            run(cmd)
         catch e
             error(
                 "Failed to run genhtml. Check that lcov is installed (see the README).",

--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -281,8 +281,9 @@ end
 """
 $(SIGNATURES)
 
-Generate, and optionally open, the HTML coverage summary in a browser for `pkg`
-inside `dir`.
+Generate, and optionally open, the HTML coverage summary in a browser
+for `pkg` inside `dir`. The optional keyword argument `css` can be
+used to set the path to a custom CSS file styling the coverage report.
 
 See [`generate_coverage`](@ref).
 """
@@ -324,9 +325,10 @@ function html_coverage(pkg = nothing;
                        dir = tempdir(),
                        test_args = [""],
                        folder_list = ["src"],
-                       file_list = [])
+                       file_list = [],
+                       css = nothing)
     gen_cov() = generate_coverage(pkg; test_args = test_args, folder_list = folder_list, file_list = file_list)
-    html_coverage(gen_cov(); gitroot = gitroot, open = open, dir = dir)
+    html_coverage(gen_cov(); gitroot = gitroot, open = open, dir = dir, css = css)
 end
 
 """

--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -287,7 +287,7 @@ used to set the path to a custom CSS file styling the coverage report.
 
 See [`generate_coverage`](@ref).
 """
-function html_coverage(coverage::PackageCoverage; gitroot = ".", open = false, dir = tempdir(), css::Union{Nothing,String}=nothing)
+function html_coverage(coverage::PackageCoverage; gitroot = ".", open = false, dir = tempdir(), css::Union{Nothing,AbstractString}=nothing)
     cd(coverage.package_dir) do
         branch = try
             LibGit2.headname(GitRepo(gitroot))

--- a/test/dummy.css
+++ b/test/dummy.css
@@ -1,0 +1,4 @@
+body {
+    color: white;
+    background-color: black;
+}


### PR DESCRIPTION
I added a keyword argument to `html_coverage` that takes the path to a custom CSS file, to be used as
```Julia
html_coverage(cov, css="path/to/custom.css")
```
Using e.g. a CSS file based on the [Gruvbox](https://github.com/gruvbox-community/gruvbox) theme, it can look like

![image](https://github.com/user-attachments/assets/f49d11ce-d60c-4fec-8492-4fcdd88e8ce1)

![image](https://github.com/user-attachments/assets/817dd0c9-e839-462e-86c5-506d24ec004f)

![image](https://github.com/user-attachments/assets/54d15eb4-3183-48a9-b46a-0619877de2b2)

![image](https://github.com/user-attachments/assets/e3c693d8-3566-4e16-a780-8e1cca31861d)

[gruvbox.zip](https://github.com/user-attachments/files/16388659/gruvbox.zip)