### PR TITLE
Coverage for failing tests

### DIFF
--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -258,7 +258,6 @@ Process coverage files for a package within folder.
 Called by [`generate_coverage`](@ref).
 
 """
-
 function process_coverage(pkg=nothing;
                           folder_list=["src"],
                           file_list=[])::PackageCoverage

--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -233,13 +233,35 @@ function generate_coverage(pkg = nothing;
                            test_args = [""],
                            folder_list = ["src"],
                            file_list = [])::PackageCoverage
-    if run_test
-        if isnothing(pkg)
-            Pkg.test(; coverage = true, test_args = test_args)
-        else
-            Pkg.test(pkg; coverage = true, test_args = test_args)
+    
+    try
+        if run_test
+            if isnothing(pkg)
+                Pkg.test(; coverage = true, test_args = test_args)
+            else
+                Pkg.test(pkg; coverage = true, test_args = test_args)
+            end
         end
+    catch e
+        coverage = process_coverage(pkg; folder_list, file_list)
+        println(stdout, coverage)
+        rethrow(e)
     end
+    return process_coverage(pkg; folder_list, file_list)
+end
+
+"""
+$(SIGNATURES)
+
+Process coverage files for a package within folder.
+    
+Called by [`generate_coverage`](@ref).
+
+"""
+
+function process_coverage(pkg=nothing;
+                          folder_list=["src"],
+                          file_list=[])::PackageCoverage
     package_dir = pkgdir(pkg)
     cd(package_dir) do
         # initialize empty vector of coverage data

--- a/test/DummyPackage/test/runtests.jl
+++ b/test/DummyPackage/test/runtests.jl
@@ -10,3 +10,9 @@ end
 @testset "testset 2" begin
     @test corge() == "corge"
 end
+
+if "testset 3" ∈ ARGS
+    @testset "testset 3" begin
+            @test 1 == 2
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,10 @@ end
         @test_throws TypeError test_coverage("DummyPackage", css=1)
         test_coverage("DummyPackage", css=joinpath(dirname(@__FILE__), "dummy.css"))
     end
+
+    @testset "failing tests" begin
+        test_coverage("DummyPackage"; test_args = ["testset 3"])
+    end
 end
 
 @test LocalCoverage.find_gaps([nothing, 0, 0, 0, 2, 3, 0, nothing, 0, 3, 0, 6, 2]) ==


### PR DESCRIPTION
Adds a safety measure to still process .cov files even when tests are failing.

Closes #57