### PR TITLE
display path to generated coverage HTML

### DIFF
--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -313,7 +313,7 @@ function html_coverage(coverage::PackageCoverage; gitroot = ".", open = false, d
                 sprint(Base.showerror, e),
             )
         end
-        @info("generated coverage HTML")
+        @info("generated coverage HTML $(joinpath(dir, "index.html")).")
         open && DefaultApplication.open(joinpath(dir, "index.html"))
     end
     nothing


### PR DESCRIPTION
Show the path to the generated HTML coverage with an `@info`, similar to how the path of a generated cobertura XML coverage report is displayed[^1].

[^1]: https://github.com/JuliaCI/LocalCoverage.jl/blob/0407e1a58286402a7d994bfc6ada40bd65351669/src/LocalCoverage.jl#L391